### PR TITLE
add pypi release workflow to CI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,165 @@
+name: Publish to PyPI
+
+# This workflow publishes the package to PyPI when:
+# 1. A new release is published (automatic PyPI publication)
+# 2. Manually triggered via workflow_dispatch (with option for TestPyPI)
+#
+# For PyPI publication, create a new release on GitHub:
+# 1. Update version in pyproject.toml and contrib_checker/__init__.py
+# 2. Create and push a new git tag: git tag v1.0.0 && git push origin v1.0.0  
+# 3. Create a GitHub release from the tag
+#
+# For TestPyPI testing:
+# 1. Go to Actions tab -> "Publish to PyPI" workflow
+# 2. Click "Run workflow" and check "Publish to Test PyPI"
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      test_pypi:
+        description: 'Publish to Test PyPI instead of PyPI'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build twine
+
+    - name: Build package
+      run: python -m build
+
+    - name: Check distribution
+      run: python -m twine check dist/*
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  test-install:
+    name: Test installation
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Install package
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install dist/*.whl
+
+    - name: Test import
+      run: |
+        python -c "import contrib_checker; print('✅ Package imports successfully')"
+        python -c "from contrib_checker import ContributorChecker, GitHubContributorChecker, GitLabContributorChecker; print('✅ All classes importable')"
+
+    - name: Test CLI
+      run: |
+        contrib-checker --help
+
+  publish-to-testpypi:
+    name: Publish to TestPyPI
+    needs: [build, test-install]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && inputs.test_pypi
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/contrib-checker
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: [build, test-install]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/contrib-checker
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  verify-pypi-publish:
+    name: Verify PyPI publication
+    needs: publish-to-pypi
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+    - name: Wait for package to be available
+      run: sleep 60
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - name: Install from PyPI
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install contrib-checker
+
+    - name: Test PyPI installation
+      run: |
+        python -c "import contrib_checker; print(f'✅ Installed version: {contrib_checker.__version__}')"
+        contrib-checker --help

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,127 @@
+# Release Process for contrib-checker
+
+This document outlines the process for releasing new versions of contrib-checker to PyPI.
+
+## Prerequisites
+
+1. **Repository Access**: Write access to the GitHub repository
+2. **PyPI Trusted Publisher**: The repository should be configured as a trusted publisher on PyPI
+3. **Clean Working Directory**: All changes committed and pushed to main branch
+
+## Release Steps
+
+### 1. Prepare the Release
+
+#### Update Version
+Use the version management script to update the version consistently:
+
+```bash
+# Check current version
+python scripts/update_version.py --show
+
+# Update to new version (example: 1.0.1)
+python scripts/update_version.py 1.0.1
+```
+
+This will update both `pyproject.toml` and `contrib_checker/__init__.py`.
+
+#### Update Changelog (Optional)
+Update `CHANGELOG.md` or release notes with new features, bug fixes, and breaking changes.
+
+#### Run Tests
+Ensure all tests pass before releasing:
+
+```bash
+python -m pytest tests/ -v
+```
+
+### 2. Commit and Tag
+
+```bash
+# Commit version changes
+git add -A
+git commit -m "Bump version to 1.0.1"
+
+# Create and push tag
+git tag v1.0.1
+git push origin main
+git push origin v1.0.1
+```
+
+### 3. Create GitHub Release
+
+1. Go to the [Releases page](https://github.com/vuillaut/contrib-checker/releases)
+2. Click "Create a new release"
+3. Select the tag you just created (v1.0.1)
+4. Set release title (e.g., "contrib-checker v1.0.1")
+5. Add release notes describing changes
+6. Click "Publish release"
+
+**The PyPI publication workflow will automatically trigger when the release is published.**
+
+### 4. Verify Publication
+
+1. **Check GitHub Actions**: Monitor the "Publish to PyPI" workflow
+2. **Verify on PyPI**: Check that the new version appears on [PyPI](https://pypi.org/project/contrib-checker/)
+3. **Test Installation**: 
+   ```bash
+   pip install --upgrade contrib-checker
+   python -c "import contrib_checker; print(contrib_checker.__version__)"
+   ```
+
+## Manual Testing (Optional)
+
+### Test PyPI Publication
+
+You can test the publication process using TestPyPI before making a real release:
+
+1. Go to GitHub Actions
+2. Select "Publish to PyPI" workflow
+3. Click "Run workflow"
+4. Check "Publish to Test PyPI instead of PyPI"
+5. Run the workflow
+
+This will publish to [test.pypi.org](https://test.pypi.org/project/contrib-checker/) for testing.
+
+### Install from TestPyPI
+
+```bash
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ contrib-checker
+```
+
+## Workflow Details
+
+The PyPI publication workflow (`.github/workflows/pypi.yml`) includes:
+
+1. **Build**: Creates source distribution and wheel
+2. **Test Installation**: Tests package installation on multiple Python versions
+3. **Publish**: Uploads to PyPI (or TestPyPI) using trusted publishing
+4. **Verify**: Confirms the package is available and installable from PyPI
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Version Already Exists**: PyPI doesn't allow overwriting existing versions. Increment the version number.
+
+2. **Trusted Publisher Not Configured**: 
+   - Go to PyPI project settings
+   - Add GitHub as a trusted publisher
+   - Configure: Owner: `vuillaut`, Repository: `contrib-checker`, Workflow: `pypi.yml`
+
+3. **Test Failures**: Fix failing tests before proceeding with release.
+
+4. **Permission Errors**: Ensure the GitHub token has necessary permissions.
+
+### Manual Publication (Fallback)
+
+If the automated workflow fails, you can publish manually:
+
+```bash
+# Build the package
+python -m build
+
+# Upload to PyPI (requires API token)
+python -m twine upload dist/*
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,13 @@ name = "contrib-checker"
 version = "1.0.0"
 description = "Check if code contributors are properly listed in metadata files such as CITATION.cff and codemeta.json based on the git history"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = {text = "MIT"}
 authors = [
     {name = "Thomas Vuillaume", email = "thomas.vuillaume@lapp.in2p3.fr"}
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Quality Assurance",

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Version management utility for contrib-checker.
+
+Usage:
+    python scripts/update_version.py 1.0.1
+    python scripts/update_version.py --show
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+def get_current_version():
+    """Get the current version from __init__.py"""
+    init_file = Path(__file__).parent.parent / "contrib_checker" / "__init__.py"
+    content = init_file.read_text()
+    match = re.search(r'__version__ = ["\']([^"\']+)["\']', content)
+    if match:
+        return match.group(1)
+    return None
+
+def update_version(new_version):
+    """Update version in both pyproject.toml and __init__.py"""
+    
+    # Update pyproject.toml
+    pyproject_file = Path(__file__).parent.parent / "pyproject.toml"
+    content = pyproject_file.read_text()
+    content = re.sub(
+        r'version = ["\'][^"\']+["\']',
+        f'version = "{new_version}"',
+        content
+    )
+    pyproject_file.write_text(content)
+    print(f"✅ Updated pyproject.toml to version {new_version}")
+    
+    # Update __init__.py
+    init_file = Path(__file__).parent.parent / "contrib_checker" / "__init__.py"
+    content = init_file.read_text()
+    content = re.sub(
+        r'__version__ = ["\'][^"\']+["\']',
+        f'__version__ = "{new_version}"',
+        content
+    )
+    init_file.write_text(content)
+    print(f"✅ Updated __init__.py to version {new_version}")
+
+def validate_version(version):
+    """Validate version format (semantic versioning)"""
+    pattern = r'^\d+\.\d+\.\d+(?:[-.]?(?:alpha|beta|rc|dev)\d*)?$'
+    return re.match(pattern, version) is not None
+
+def main():
+    parser = argparse.ArgumentParser(description="Manage contrib-checker version")
+    parser.add_argument("version", nargs="?", help="New version to set")
+    parser.add_argument("--show", action="store_true", help="Show current version")
+    
+    args = parser.parse_args()
+    
+    if args.show:
+        current = get_current_version()
+        if current:
+            print(f"Current version: {current}")
+        else:
+            print("❌ Could not determine current version")
+            sys.exit(1)
+        return
+    
+    if not args.version:
+        current = get_current_version()
+        print(f"Current version: {current}")
+        print("Usage: python scripts/update_version.py <new_version>")
+        print("Example: python scripts/update_version.py 1.0.1")
+        return
+    
+    new_version = args.version
+    
+    if not validate_version(new_version):
+        print(f"❌ Invalid version format: {new_version}")
+        print("Expected format: X.Y.Z (semantic versioning)")
+        sys.exit(1)
+    
+    current = get_current_version()
+    print(f"Updating version from {current} to {new_version}")
+    
+    try:
+        update_version(new_version)
+        print("\n🎉 Version updated successfully!")
+        print("\nNext steps:")
+        print(f"1. Commit the changes: git add -A && git commit -m 'Bump version to {new_version}'")
+        print(f"2. Create and push tag: git tag v{new_version} && git push origin v{new_version}")
+        print("3. Create GitHub release from the tag to trigger PyPI publication")
+    except Exception as e:
+        print(f"❌ Error updating version: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
🚀 Main Components:
pypi.yml - Comprehensive PyPI publication workflow with:

1. Automatic publication when GitHub releases are created
Manual testing via workflow_dispatch to TestPyPI
Multi-Python version testing (3.8-3.12)
Build verification and package validation
Trusted publisher authentication (secure, no API keys needed)
update_version.py - Version management utility to:

2. Update versions consistently across pyproject.toml and __init__.py
Validate semantic versioning format
Provide clear next steps for release process
RELEASE.md - Complete documentation covering:

3. Step-by-step release process
PyPI trusted publisher setup
TestPyPI testing procedures
Troubleshooting common issues
Version numbering guidelines


🔧 Workflow Features:
Triggers:
Release Publication: Automatically publishes to PyPI when a GitHub release is created
Manual Dispatch: Allows testing with TestPyPI before real releases